### PR TITLE
Feature/rocket setup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,22 @@
 import './App.css';
 import { Routes, Route } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { useEffect } from 'react';
 import Nav from './components/Nav';
+import { fetchRockets } from './redux/rockets/rocketSlice';
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchRockets());
+  }, [dispatch]);
+
   return (
     <div className="main">
       <Nav />
       <Routes>
-        <Route className="navbar-link" path="/rockets" />
+        <Route className="navbar-link" path="/" />
         <Route className="navbar-link" path="/missions" />
         <Route className="navbar-link" path="/profile" />
       </Routes>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -21,7 +21,7 @@ const Nav = () => {
         <ul className="nav-ul">
           <li className="nav-li">
             <NavLink
-              to="/rockets"
+              to="/"
             >
               Rockets
             </NavLink>

--- a/src/redux/rockets/rocketSlice.js
+++ b/src/redux/rockets/rocketSlice.js
@@ -1,0 +1,42 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const rocketAPI = 'https://api.spacexdata.com/v3/Rockets';
+export const fetchRockets = createAsyncThunk(
+  'rockets/fetchRockets API Data',
+  async () => {
+    const response = await axios.get(rocketAPI);
+    return response.data;
+  },
+);
+
+const rocketReducer = createSlice({
+  name: 'Pocket-Me-Rocket-He',
+  initialState: {
+    rocketArr: [],
+    isLoading: false,
+    error: null,
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchRockets.pending, (state) => {
+        state.isLoading = false;
+      })
+      .addCase(fetchRockets.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.rocketArr = action.payload.map((rocketItems) => ({
+          id: rocketItems.id,
+          rocket_name: rocketItems.rocket_name,
+          rocket_type: rocketItems.rocket_type,
+          flickr_images: rocketItems.flickr_images,
+        }));
+      })
+      .addCase(fetchRockets.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.error;
+      });
+  },
+});
+
+export default rocketReducer.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import missionsReducer from './missions/missionsSlice';
+import rocketReducer from './rockets/rocketSlice';
 
 const store = configureStore({
   reducer: {
     missions: missionsReducer,
+    rockets: rocketReducer,
   },
 });
 


### PR DESCRIPTION
Dear Team,
Please review the below changes on this PR to approve merge.

- [x] Added `rocketSlice.js` inside the redux directory to handle the Rockets data in the Redux store. This slice includes an asynchronous thunk fetchRockets that fetches data from the [Rockets endpoint](https://api.spacexdata.com/v3/rockets) when the application starts.
- [x] Implemented the `useEffect hook` in `App.js` to dispatch the `fetchRockets` async thunk when the app loads. This ensures that the Rockets data is fetched and stored in the Redux store only once, preventing multiple API requests on re-renders (e.g., when changing views or using navigation).
- [x] Dispatched an action inside the `fetchRockets` async thunk to store the selected data from the API response in the Redux store. The selected data includes the following properties: `id`, `rocket_name`, `rocket_type`, and `flickr_images`.

The above changes fulfill the project requirements, allowing the app to fetch Rockets data from the SpaceX API on app load and store the selected data in the Redux store. The data is available throughout the application without making additional API calls on re-renders.

Please review the changes and let me know if there are any further improvements or adjustments needed. Thank you!

Regards,
@Zafron047 